### PR TITLE
Conception refactor

### DIFF
--- a/src/components/ContractDialog/PDFPrevisualisation/SendContractTo.tsx
+++ b/src/components/ContractDialog/PDFPrevisualisation/SendContractTo.tsx
@@ -92,6 +92,14 @@ export function SendContractTo(props: {
                 form.append("to", mailTo())
                 form.append("body", mailBody())
 
+                const contractData = currentPDFTool()?.contractData
+                if (contractData !== undefined) {
+                    form.append("contractAuth", JSON.stringify({
+                        id: contractData.id,
+                        token: contractData.token
+                    }))
+                }
+
                 await mailService.sendContratTo(form)
                 NotificationService.push({
                     content: "Contrat envoyé.",

--- a/src/components/ContractEditor/CTAPDFViewer.tsx
+++ b/src/components/ContractEditor/CTAPDFViewer.tsx
@@ -7,85 +7,100 @@ import { NotificationService } from "../../utils/notification.service";
 import storeService from "../../utils/store.service";
 import { PDFViewerPrevisualisationDialog } from "../ContractDialog/PDFPrevisualisation/PDFViewerPrevisualisationDialog";
 import { currentPDFTool } from "./PDFEditor";
-import { loggedIn, loadContract, setLoadContrat } from "../../const.data";
+import { loadContract } from "../../const.data";
 
-function createContractID(): string {
-    const timestamp = Date.now().toString(36);
-    const randomPart = Math.random().toString(36).substring(2, 15);
-    return `contract_${timestamp}_${randomPart}`;
-}
+// function createContractID(): string {
+//     const timestamp = Date.now().toString(36);
+//     const randomPart = Math.random().toString(36).substring(2, 15);
+//     return `contract_${timestamp}_${randomPart}`;
+// }
 
 export function CTAPDFViewer() {
     async function saveContractInDB() {
         const contractFromPDF: Partial<ContractEntity> = currentPDFTool()!.getContractData()
 
-        if (import.meta.env.DEV) {
-            console.log("currentPDFTool()!.getContractData()", currentPDFTool());
-            console.log("Données du contrat avant envoi:", {
-                contractData: contractFromPDF
+        if (!loadContract() || loadContract() == undefined) {
+            const contract = await contractService.createContract(contractFromPDF);
+            contract.updatedAt = new Date(Date.now())
+            storeService.proxy.contracts = [...storeService.proxy.contracts!, contract]
+            NotificationService.push({
+                content: "Contrat sauvegarder",
+                type: "info",
+            });
+        } else {
+            const contract = await contractService.update(contractFromPDF);
+
+            storeService.proxy.contracts = storeService.proxy.contracts?.map(_contract => {
+                if (_contract.id == contract.id) return contract
+                return _contract
+            })
+
+            NotificationService.push({
+                content: "Contrat mis à jour",
+                type: "info",
             });
         }
-        if (loggedIn()) {
-            if (!loadContract()) {
 
-                const contract = await contractService.createContract(contractFromPDF);
-                contract.updatedAt = new Date(Date.now())
-                storeService.proxy.contracts = [...storeService.proxy.contracts!, contract]
-                NotificationService.push({
-                    content: "Contrat sauvegarder comme brouillon",
-                    type: "info",
-                });
-            } else {
-                const contract = await contractService.update(contractFromPDF);
+        // if (loggedIn()) {
+        //     if (!loadContract()) {
+        //         const contract = await contractService.createContract(contractFromPDF);
+        //         contract.updatedAt = new Date(Date.now())
+        //         storeService.proxy.contracts = [...storeService.proxy.contracts!, contract]
+        //         NotificationService.push({
+        //             content: "Contrat sauvegarder comme brouillon",
+        //             type: "info",
+        //         });
+        //     } else {
+        //         const contract = await contractService.update(contractFromPDF);
 
-                storeService.proxy.contracts = storeService.proxy.contracts?.map(_contract => {
-                    if (_contract.id == contract.id) {
-                        return contract
-                    }
-                    return _contract
-                })
+        //         storeService.proxy.contracts = storeService.proxy.contracts?.map(_contract => {
+        //             if (_contract.id == contract.id) {
+        //                 return contract
+        //             }
+        //             return _contract
+        //         })
 
-                NotificationService.push({
-                    content: "Contrat mis à jour",
-                    type: "info",
-                });
-            }
+        //         NotificationService.push({
+        //             content: "Contrat mis à jour",
+        //             type: "info",
+        //         });
+        //     }
 
-        } else {
-            if (!storeService.proxy.contracts) storeService.proxy.contracts = []
+        // } else {
+        //     if (!storeService.proxy.contracts) storeService.proxy.contracts = []
 
-            if (!loadContract()) {
-                storeService.proxy.contracts = [
-                    ...storeService.proxy.contracts,
-                    {
-                        id: createContractID(),
-                        logoutCreate: true,
-                        ...contractFromPDF,
-                    },
-                ];
+        //     if (!loadContract()) {
+        //         storeService.proxy.contracts = [
+        //             ...storeService.proxy.contracts,
+        //             {
+        //                 id: createContractID(),
+        //                 logoutCreate: true,
+        //                 ...contractFromPDF,
+        //             },
+        //         ];
 
-                setLoadContrat(contractFromPDF)
+        //         setLoadContrat(contractFromPDF)
 
-                NotificationService.push({
-                    content: "Contrat sauvegarder comme brouillon",
-                    type: "info",
-                });
+        //         NotificationService.push({
+        //             content: "Contrat sauvegarder comme brouillon",
+        //             type: "info",
+        //         });
 
-            } else {
-                let contracts: Partial<ContractEntity>[] = storeService.proxy.contracts
-                storeService.proxy.contracts = contracts.map(contract => {
-                    if (contract.id == contractFromPDF.id) {
-                        contract = contractFromPDF
-                    }
-                    return contract
-                })
+        //     } else {
+        //         let contracts: Partial<ContractEntity>[] = storeService.proxy.contracts
+        //         storeService.proxy.contracts = contracts.map(contract => {
+        //             if (contract.id == contractFromPDF.id) {
+        //                 contract = contractFromPDF
+        //             }
+        //             return contract
+        //         })
 
-                NotificationService.push({
-                    content: "Contrat mis à jour",
-                    type: "info",
-                });
-            }
-        }
+        //         NotificationService.push({
+        //             content: "Contrat mis à jour",
+        //             type: "info",
+        //         });
+        //     }
+        // }
     }
 
     function downloadPDF() {

--- a/src/components/FloattingMenu/bottom-menu-dialog/bottom-menu-page/bottom-menu-pages/BottomMenuPageContract.tsx
+++ b/src/components/FloattingMenu/bottom-menu-dialog/bottom-menu-page/bottom-menu-pages/BottomMenuPageContract.tsx
@@ -25,35 +25,50 @@ export function BottomMenuPageContract() {
     setFilteredContracts(updatedContracts);
   }))
 
-  async function SynchronizeContracts() {
-    const contracts = storeService.proxy.contracts as Partial<ContractEntity>[]
-    const request = await contractService.registerLocaleContractToBDD(contracts)
-    storeService.proxy.contracts = request
-  }
+  // async function SynchronizeContracts() {
+  //   const contracts = storeService.proxy.contracts as Partial<ContractEntity>[]
+  //   const request = await contractService.registerLocaleContractToBDD(contracts)
+  //   storeService.proxy.contracts = request
+  // }
 
   onMount(async () => {
-    const localContracts = storeService.proxy.contracts;
-    // Initialiser les contrats avec les données du store
-    if (localContracts && localContracts.length > 0) {
-      const contractsList = localContracts as ContractEntity[];
-      setContracts(contractsList);
-      setFilteredContracts(contractsList);
+    if (loggedIn()) {
+      const contracts = await contractService.list();
+      setContracts(contracts);
+    } else {
+      // const ids = storeService.proxy.contracts?.map(contract => [contract.id, contract.token]) as [[string | number, string]];
+      let ids = []
+      for (const contract of storeService.proxy.contracts!) {
+        ids.push([contract.id, contract.token]);
+      }
+
+
+      const contracts = await contractService.listFromIDS(ids as [number, string][]);
+      setContracts(contracts);
     }
 
-    if (loggedIn()) {
-      if (localContracts!.length > 0) {
-        await SynchronizeContracts();
-        // Mettre à jour après synchronisation
-        const updatedContracts = storeService.proxy.contracts as ContractEntity[];
-        setContracts(updatedContracts);
-        setFilteredContracts(updatedContracts);
-      } else {
-        const contractsList = await contractService.list();
-        storeService.proxy.contracts = contractsList;
-        setContracts(contractsList);
-        setFilteredContracts(contractsList);
-      }
-    }
+    // const localContracts = storeService.proxy.contracts;
+    // // Initialiser les contrats avec les données du store
+    // if (localContracts && localContracts.length > 0) {
+    //   const contractsList = localContracts as ContractEntity[];
+    //   setContracts(contractsList);
+    //   setFilteredContracts(contractsList);
+    // }
+
+    // if (loggedIn()) {
+    //   if (localContracts!.length > 0) {
+    //     // await SynchronizeContracts();
+    //     // Mettre à jour après synchronisation
+    //     const updatedContracts = storeService.proxy.contracts as ContractEntity[];
+    //     setContracts(updatedContracts);
+    //     setFilteredContracts(updatedContracts);
+    //   } else {
+    //     const contractsList = await contractService.list();
+    //     storeService.proxy.contracts = contractsList;
+    //     setContracts(contractsList);
+    //     setFilteredContracts(contractsList);
+    //   }
+    // }
   });
 
   function openDialogTool_(contract: ContractEntity) {

--- a/src/components/dialog/DialogWrapper.tsx
+++ b/src/components/dialog/DialogWrapper.tsx
@@ -9,7 +9,8 @@ interface DialogWrapperProps {
   children: JSX.Element;
   btnText: string;
   title: string;
-  onClose?: () => void
+  onClose?: () => void;
+  onOpen?: () => void;
   dialogClass?: string
 }
 
@@ -19,10 +20,16 @@ export const openDialogTool = () => setIsOpen(true);
 
 export function DialogWrapper(props: DialogWrapperProps) {
 
+  function removeSigneBackQuery() {
+    const queryParams = new URLSearchParams(window.location.search);
+    queryParams.delete("signe-back");
+    window.history.replaceState({}, "", window.location.pathname + "?" + queryParams.toString());
+  }
   async function closeDialogTool() {
     setLoadContrat(undefined);
     setCurrentPDFTool(undefined);
     setIsOpen(false);
+    removeSigneBackQuery();
   };
 
   return (

--- a/src/models/contract.entity.ts
+++ b/src/models/contract.entity.ts
@@ -39,4 +39,6 @@ export type ContractEntity = {
   deleted?: boolean
 
   updatedAt?: Date
+
+  token?: string
 };

--- a/src/pages/PageWrapper.tsx
+++ b/src/pages/PageWrapper.tsx
@@ -4,6 +4,12 @@ import { Navbar } from "../components/navbar/Navbar";
 import { Notification } from "../components/notification/Notification";
 import { FloatingMenu } from "../components/FloattingMenu/floating-menu/FloatingMenu";
 import { setNavigateFunction } from "../services/auth.service";
+import { contractService } from "../services/contract.service";
+
+import { setLoadContrat } from "../const.data";
+import { ContractEntity } from "../models/contract.entity";
+import { openDialogTool } from "../components/dialog/DialogWrapper";
+import storeService from "../utils/store.service";
 
 interface PageWrapperProps {
     children: JSXElement;
@@ -16,8 +22,22 @@ export function PageWrapper(props: PageWrapperProps) {
     const childs = children(() => props.children);
     const navigate = useNavigate();
 
-    onMount(() => {
+    onMount(async () => {
         setNavigateFunction(navigate);
+
+        const queryParams = new URLSearchParams(window.location.search);
+        const token = queryParams.get("signe-back");
+
+        if (token) {
+            const contract = await contractService.getContractByToken(token);
+            if (contract) {
+                setLoadContrat(contract as Partial<ContractEntity>);
+                setSigneBack(true)
+                openDialogTool()
+
+                storeService.proxy.signeBackContracts = [contract];
+            }
+        }
     });
 
     return (

--- a/src/pages/PageWrapper.tsx
+++ b/src/pages/PageWrapper.tsx
@@ -1,20 +1,42 @@
-import { children, JSXElement, onMount } from "solid-js";
+import { children, createSignal, JSXElement, onMount } from "solid-js";
 import { useNavigate } from "@solidjs/router";
 import { Navbar } from "../components/navbar/Navbar";
 import { Notification } from "../components/notification/Notification";
 import { FloatingMenu } from "../components/FloattingMenu/floating-menu/FloatingMenu";
 import { setNavigateFunction } from "../services/auth.service";
+import { contractService } from "../services/contract.service";
+
+import { setLoadContrat } from "../const.data";
+import { ContractEntity } from "../models/contract.entity";
+import { openDialogTool } from "../components/dialog/DialogWrapper";
+import storeService from "../utils/store.service";
 
 interface PageWrapperProps {
     children: JSXElement;
 }
 
+export const [signeBack, setSigneBack] = createSignal<boolean>(false);
+
 export function PageWrapper(props: PageWrapperProps) {
     const childs = children(() => props.children);
     const navigate = useNavigate();
 
-    onMount(() => {
+    onMount(async () => {
         setNavigateFunction(navigate);
+
+        const queryParams = new URLSearchParams(window.location.search);
+        const token = queryParams.get("signe-back");
+
+        if (token) {
+            const contract = await contractService.getContractByToken(token);
+            if (contract) {
+                setLoadContrat(contract as Partial<ContractEntity>);
+                setSigneBack(true)
+                openDialogTool()
+
+                storeService.proxy.signeBackContracts = [contract];
+            }
+        }
     });
 
     return (

--- a/src/pages/home/HeroSection.tsx
+++ b/src/pages/home/HeroSection.tsx
@@ -1,11 +1,11 @@
 import { EditContractDialog } from "../../components/ContractDialog/EditContractDialog";
 import { Button } from "../../components/buttons/Button";
 import { Title1 } from "../../components/titles/Title1";
-import storeService from "../../utils/store.service";
 import { Text } from "../../components/titles/Text";
 import { Show } from "solid-js";
 import { HiOutlineInformationCircle } from 'solid-icons/hi';
 import { useNavigate } from "@solidjs/router";
+import { loggedIn } from "../../const.data";
 
 export function HeroSection() {
     const navigate = useNavigate();
@@ -19,7 +19,7 @@ export function HeroSection() {
             <Text text="Kiné de poche est un outil dédié aux kinésithérapeutes, conçu pour simplifier la création de contrats. Gagnez du temps en générant automatiquement des documents conformes et personnalisés en quelques clics." />
 
             <span class="my-2" />
-            <Show when={!storeService.proxy.isLogin}>
+            <Show when={!loggedIn()}>
                 <div class="flex flex-wrap gap-3 w-full justify-center md:justify-start">
                     <Button
                         bgGradientStyle="right"

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -5,9 +5,10 @@ export function Home() {
   return (
     <PageWrapper>
 
-      <div class="">        <HeroSection />
-
+      <div class="">
+        <HeroSection />
         {/* <Announcements announcements={announcements} /> */}
-      </div>    </PageWrapper>
+      </div>
+    </PageWrapper>
   );
 }

--- a/src/services/contract.service.ts
+++ b/src/services/contract.service.ts
@@ -17,9 +17,9 @@ class ContractService {
     return response as ContractEntity[];
   }
 
-  async listFromIDS(ids: (string | number)[]): Promise<ContractEntity[]> {
-    const idsParam = ids.map(id => encodeURIComponent(String(id))).join(',');
-    const response = await FetcherService.get("/contract/list-ids?ids=" + idsParam);
+  // * TODO update aray for [[id, token], [id, token], ...]
+  async listFromIDS(ids: [number, string][]): Promise<ContractEntity[]> {
+    const response = await FetcherService.post("/contract/list-ids", { ids: JSON.stringify(ids) });
     return response as ContractEntity[];
   }
 
@@ -41,9 +41,10 @@ class ContractService {
     await FetcherService.delete("/contract/" + id);
   }
 
-  async registerLocaleContractToBDD(contracts: Partial<ContractEntity>[]): Promise<Partial<ContractEntity>[]> {
-    const response = await FetcherService.post("/contract/register-local-contrats", { contracts });
-    return response as Partial<ContractEntity>[];
+  async getContractByToken(token: string): Promise<ContractEntity> {
+    const response = await FetcherService.get("/contract/get-by-token?token=" + token);
+    return response as ContractEntity;
   }
+
 }
 export const contractService = new ContractService();

--- a/src/utils/store.service.ts
+++ b/src/utils/store.service.ts
@@ -6,7 +6,8 @@ export const [localeUpdateEvent, setLocalUpdateEvent] = createSignal<boolean>(fa
 type StoreDataType = {
   [key: string]: any;
   isLogin: boolean | undefined;
-  contracts?: Partial<ContractEntity>[]
+  contracts?: Partial<ContractEntity>[];
+  signeBackContracts?: Partial<ContractEntity>[];
 };
 
 class StoreService {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces token-based contract fetch/list behavior and passes contract auth data in email sends, changing client/server contract API shapes and access patterns. Risk is moderate due to potential mismatches with backend expectations and edge cases around missing/invalid tokens or local store state.
> 
> **Overview**
> Adds a *token-based access path* for contracts: `PageWrapper` now detects a `signe-back` query param, fetches the contract via a new `getContractByToken` API call, preloads it into `loadContract`, opens the edit dialog, and stores it in `storeService`.
> 
> Updates contract listing for logged-out users to fetch contracts from the backend using `[id, token]` pairs via a modified `listFromIDS` (now `POST /contract/list-ids`), and extends `ContractEntity`/store to carry optional `token` and `signeBackContracts`.
> 
> When emailing a generated PDF, the client now includes `contractAuth` (`id` + `token`) in the `FormData`. Contract save logic in `CTAPDFViewer` is simplified to always `create` when no `loadContract` exists, otherwise `update` (removing the previous logged-in vs local-only draft paths).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9053b4eb83a8bafd382647c798246ec44e29028. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->